### PR TITLE
Recommend Superpowers as first agent skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "inverter-standard",
+  "owner": {
+    "name": "Inverter Network"
+  },
+  "metadata": {
+    "description": "Inverter Network — curated AI agent skills and plugins for Claude Code",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "superpowers",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/obra/superpowers.git"
+      },
+      "description": "Agentic skills framework — brainstorm → plan → TDD → review → finish. Recommended for all non-trivial Inverter dev work.",
+      "version": "5.0.7",
+      "strict": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Inverter AI Standard
+
+This repository is the Inverter Network AI Standard — the central reference for approved AI tools, reusable skills, and acceptable-use policies across the company. Start at [`ai/README.md`](./ai/README.md).
+
+## Recommended setup
+
+Inverter recommends installing [Superpowers](./ai/skills/workflows/superpowers.md) — an agentic skills framework that enforces a brainstorm → plan → TDD → review → finish workflow. The skills auto-trigger for non-trivial dev work; no manual invocation needed. License: MIT.
+
+### Install per agent
+
+| Agent | Command |
+|---|---|
+| **Claude Code** *(Inverter marketplace — recommended)* | `/plugin marketplace add InverterNetwork/standard` then `/plugin install superpowers@inverter-standard` |
+| Claude Code *(upstream marketplace)* | `/plugin install superpowers@claude-plugins-official` |
+| Codex CLI | `/plugins`, search `superpowers`, select **Install Plugin** |
+| Codex App | Plugins sidebar → click `+` next to Superpowers |
+| Cursor | `/add-plugin superpowers` (or search the plugin marketplace) |
+| GitHub Copilot CLI | `copilot plugin marketplace add obra/superpowers-marketplace` then `copilot plugin install superpowers@superpowers-marketplace` |
+| OpenCode | Tell it: `Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md` |
+| Gemini CLI | `gemini extensions install https://github.com/obra/superpowers` |
+
+Restart your agent after installing.
+
+## Inverter plugin marketplace
+
+The repo also publishes a curated Claude Code plugin marketplace at [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json). It currently lists only Superpowers; future Inverter-approved skills will be added there. The marketplace is a Claude-Code-specific convenience — other agents install Superpowers directly via the table above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/ai/README.md
+++ b/ai/README.md
@@ -29,11 +29,14 @@ Reusable prompt patterns and techniques organised by domain. Skills are concrete
 
 → **[Skills Overview](./skills/README.md)**
 
+> **Using an AI agent?** See [`AGENTS.md`](../AGENTS.md) at the repo root for per-agent install commands for the recommended Inverter skill bundle (works with Claude Code, Cursor, Codex, OpenCode, Copilot, and Gemini). Claude Code users get an additional one-command shortcut via the curated [plugin marketplace](../.claude-plugin/marketplace.json).
+
 | Domain | Skills |
 |--------|--------|
 | Solidity Development | [Testing](./skills/solidity-development/testing/README.md) (skeleton · modifiers · internal functions · external functions · fuzz · e2e · invariant) · [Commit Messages](./skills/solidity-development/commit-messages.md) |
 | QA Testing | [Guided User Testing](./skills/qa-testing/guided-user-testing.md) (base template) · [Floor Markets Phase 2](./skills/qa-testing/floor-markets-phase-2.md) |
 | Diagramming | [Excalidraw Diagram Creator](./skills/diagramming/excalidraw-diagram/SKILL.md) |
+| Workflows | [Superpowers](./skills/workflows/superpowers.md) |
 | Contributing | [Adding Content](./skills/contributing/adding-content.md) |
 
 ## Rules

--- a/ai/skills/README.md
+++ b/ai/skills/README.md
@@ -42,6 +42,16 @@ AI-assisted diagram creation — visual arguments, not just labelled boxes.
 
 → See the [Diagramming overview](./diagramming/README.md) for details.
 
+### Workflows
+
+General agent workflows and methodologies that apply across domains. Distributed via the [Inverter Claude Code marketplace](../../.claude-plugin/marketplace.json).
+
+| Skill | Description |
+|-------|-------------|
+| [Superpowers](./workflows/superpowers.md) | Agentic skills framework — brainstorm → plan → TDD → review → finish |
+
+→ See the [Workflows overview](./workflows/README.md) for details.
+
 ### Contributing
 
 How to add new content to the AI standard.

--- a/ai/skills/workflows/README.md
+++ b/ai/skills/workflows/README.md
@@ -1,0 +1,18 @@
+# Workflow Skills
+
+Skills that shape *how* an AI agent works — methodologies and disciplined collaboration patterns that apply across domains. These pair with domain-specific skills (e.g. [Solidity Development](../solidity-development/README.md), [QA Testing](../qa-testing/README.md)) to handle process discipline alongside the actual work.
+
+Workflow skills in this section work across the AI agents listed in [Approved Tools](../../tools/README.md) — Claude Code, Cursor, Codex, etc. Each agent has its own install path; see the per-agent install table in [`AGENTS.md`](../../../AGENTS.md). Claude Code users get an additional one-command shortcut via the [Inverter plugin marketplace](../../../.claude-plugin/marketplace.json):
+
+```
+/plugin marketplace add InverterNetwork/standard
+/plugin install superpowers@inverter-standard
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| [Superpowers](./superpowers.md) | Agentic skills framework — brainstorm → plan → TDD → review → finish |
+
+→ See [Adding Content](../contributing/adding-content.md) for how to add a new workflow skill or extend the marketplace.

--- a/ai/skills/workflows/superpowers.md
+++ b/ai/skills/workflows/superpowers.md
@@ -1,0 +1,70 @@
+# Superpowers
+
+[Superpowers](https://github.com/obra/superpowers) by Jesse Vincent — an agentic skills framework that ships installers for Claude Code, Codex (CLI + App), Cursor, OpenCode, GitHub Copilot, and Gemini (MIT license). It's the first skill listed in the Inverter recommended bundle.
+
+## Why it's in the Inverter bundle
+
+Inverter dev work involves smart contracts, security-sensitive logic, and long-form features that benefit from up-front design and rigorous testing. Superpowers enforces a workflow that matches how we want AI-assisted development to happen:
+
+1. **Brainstorm before code** — Socratic refinement, design doc, user sign-off
+2. **Plan in small tasks** — exact file paths, expected diffs, verification steps
+3. **TDD by default** — red → green → refactor; no implementation without a failing test first
+4. **Review before merge** — checks against the plan, severity-ranked issues
+5. **Clean finish** — tests pass, branch decision presented, worktree cleaned up
+
+The skills auto-trigger; the agent picks the right phase on its own. No manual invocation needed.
+
+## When to use
+
+- Non-trivial features, bugfixes, or refactors
+- Anywhere consistent test-driven, plan-driven output across the team matters
+- Long autonomous runs (the agent stays on-plan for an hour+ without deviating)
+
+## When to skip
+
+- One-line fixes or trivial edits where the workflow ceremony exceeds the value
+- Throwaway exploratory work
+
+## Install
+
+For Claude Code (Inverter marketplace — recommended):
+
+```
+/plugin marketplace add InverterNetwork/standard
+/plugin install superpowers@inverter-standard
+```
+
+For Codex, Cursor, OpenCode, Copilot, or Gemini, see the per-agent install table in [`AGENTS.md`](../../../AGENTS.md). Restart your agent after installing; verify the skills are loaded (e.g. `/plugin` in Claude Code).
+
+## What's inside
+
+The plugin ships ~14 skills. The core workflow:
+
+| Phase | Skill |
+|-------|-------|
+| 1 | `brainstorming` |
+| 2 | `using-git-worktrees` |
+| 3 | `writing-plans` |
+| 4 | `subagent-driven-development` / `executing-plans` |
+| 5 | `test-driven-development` |
+| 6 | `requesting-code-review` |
+| 7 | `finishing-a-development-branch` |
+
+Plus debugging (`systematic-debugging`, `verification-before-completion`), collaboration (`dispatching-parallel-agents`, `receiving-code-review`), and meta (`writing-skills`, `using-superpowers`) skills.
+
+## Combine with project skills
+
+Superpowers handles the *how* of working. Pair it with Inverter's domain skills for the *what*:
+
+- [Solidity Testing](../solidity-development/testing/README.md) — building complete test suites
+- [QA Testing](../qa-testing/README.md) — guided product testing
+
+## Pin and audit
+
+The Inverter marketplace currently lists Superpowers at version `5.0.7` ([source repo](https://github.com/obra/superpowers)). When bumping the pinned version in [`.claude-plugin/marketplace.json`](../../../.claude-plugin/marketplace.json), apply the same audit discipline as for submodules — see [Importing Submodules](../contributing/adding-content.md#importing-submodules). Diff upstream `hooks/` and `scripts/` for anything that runs at install time.
+
+## References
+
+- Source: [obra/superpowers](https://github.com/obra/superpowers) (MIT)
+- Release announcement: [blog.fsck.com/2025/10/09/superpowers/](https://blog.fsck.com/2025/10/09/superpowers/)
+- Inverter marketplace: [`.claude-plugin/marketplace.json`](../../../.claude-plugin/marketplace.json)


### PR DESCRIPTION
## Recommend Superpowers as Inverter's first agent skill

Adds a mechanism so anyone in the company — using any of our approved AI agents — discovers and installs [Superpowers](https://github.com/obra/superpowers) when they open this repo with their agent. Sets up the same delivery pipeline for any future Inverter-approved skills.

### Why

The Inverter AI Standard catalogues approved tools and skills, but until now there was no mechanism for **recommendations to actually reach an agent's context**. Cloning the repo gave you docs to read; the agent itself learned nothing. This PR fixes that: any agent that indexes this repo now sees the recommendation auto-loaded into its session, and Claude Code users get a one-command install via a curated Inverter plugin marketplace.

Superpowers is the first skill we're recommending because it enforces a workflow we actively want for non-trivial dev work — brainstorm → plan → TDD → review → finish. Future Inverter-approved skills land in the same pipeline without restructuring.

### Approach

Three layered mechanisms, each using its native ecosystem convention:

1. **`AGENTS.md` at repo root** — the cross-tool standard read by Codex, Cursor, Copilot, OpenCode, Aider, and Gemini. Contains the per-agent install table (one row per supported agent) and brief framing of *why* Superpowers is recommended.
2. **`CLAUDE.md` at repo root → one-line `@AGENTS.md` import** — Claude Code only auto-loads files literally named `CLAUDE.md`, but supports an `@path` import directive. The shim is the pattern Anthropic explicitly documents for repos using AGENTS.md for other agents. Single source of truth, zero duplication.
3. **`.claude-plugin/marketplace.json`** — Inverter-curated Claude Code plugin marketplace (`inverter-standard`) listing Superpowers v5.0.7 (MIT, source `obra/superpowers`). Gives Claude users a one-command install (`/plugin install superpowers@inverter-standard`). Other agents install via their own plugin systems because there's no cross-tool marketplace standard. Framed in docs as a Claude convenience, not the canonical recommendation.

### Alternatives considered

| Approach | Why not |
|---|---|
| **Flat documentation `.md` only** | Doesn't reach the agent's context. Anyone has to manually read the doc and decide to install. Loses the "indexing the repo recommends the skill" property entirely. |
| **Git submodule (vendoring `obra/superpowers`)** | Originally proposed because the existing `excalidraw-diagram` skill uses this pattern and the contribution guide has an "Importing Submodules" section. Rejected after subagent review: (a) Superpowers is loaded by agents from their own plugin systems, not from a vendored path here — vendoring is purely documentary; (b) upstream is a multi-platform plugin distribution (~2.5 MB of hooks, marketplace JSON, Codex/Cursor/Gemini wrappers, release notes) that's runtime-irrelevant to a docs repo; (c) the existing excalidraw submodule is uninitialised on fresh clones — the precedent is already silently failing. |
| **`CLAUDE.md` at root, no AGENTS.md** | First attempt. Caught in review: privileges Claude Code over the rest of the approved-tools roster (Cursor, ChatGPT, Codex). The repo's own framing is multi-tool; the discovery mechanism should match. |
| **AGENTS.md only, no CLAUDE.md** | Claude Code does not read AGENTS.md (confirmed in [Anthropic's memory docs](https://code.claude.com/docs/en/memory#agents-md)). Without the shim, Claude Code users would silently miss the recommendation. |
| **Symlink `CLAUDE.md → AGENTS.md`** | Works on Linux/macOS, breaks on Windows. The `@AGENTS.md` import is portable. |

### Verification

- **Schema**: `.claude-plugin/marketplace.json` validates as JSON; structure matches the working example at [`obra/superpowers-marketplace`](https://github.com/obra/superpowers-marketplace/blob/main/.claude-plugin/marketplace.json).
- **`@import` syntax**: Verified against [Anthropic's memory docs](https://code.claude.com/docs/en/memory#import-additional-files). Documented, supports relative/absolute paths, recursive up to 5 hops; imports inside the project tree don't trigger the approval dialog. The `@AGENTS.md` shim is given as the canonical example for multi-agent repos.
- **Walk-up-the-tree rule** (from `ai/skills/contributing/adding-content.md`): every README between `ai/skills/workflows/superpowers.md` and `ai/README.md` has been updated.
- **Independent review**: An adversarial subagent review of the initial submodule-based approach surfaced the vendoring-vs-documentation distinction and confirmed the marketplace-plus-AGENTS.md shape.

### Files changed

**New**
- `AGENTS.md` — cross-tool recommendation + per-agent install table
- `CLAUDE.md` — single-line `@AGENTS.md` import
- `.claude-plugin/marketplace.json` — Inverter Claude Code marketplace listing Superpowers
- `ai/skills/workflows/README.md` — workflow skills area README
- `ai/skills/workflows/superpowers.md` — catalog entry (why, when to use/skip, install, audit notes)

**Modified**
- `ai/README.md` — multi-tool callout under Skills + Workflows row in the domain table
- `ai/skills/README.md` — Workflows section linking marketplace and new skill

### Known issues / follow-ups (out of scope here)

- **Excalidraw submodule is broken on fresh clones.** `ai/skills/diagramming/excalidraw-diagram` is a gitlink to `coleam00/excalidraw-diagram-skill` but was never `submodule update --init`-ed, so the link in `ai/README.md` 404s for new contributors. Pre-existing; flagged so it doesn't get conflated with the Workflows mechanism. Worth a separate PR.
- **Pinning is loose.** The marketplace entry tracks upstream `main` (no `ref` field, matching obra's own marketplace pattern). For stricter supply-chain control, add `"ref": "<sha-or-tag>"` to `plugins[0].source`. Bump audit guidance is in `ai/skills/workflows/superpowers.md`.
- **`owner.email` omitted** in `marketplace.json` — set to a team address (`team@inverter.network`?) if desired.
- **Contribution guide doesn't yet mention the marketplace pattern.** A follow-up to `ai/skills/contributing/adding-content.md` should cover how to add a new plugin to `.claude-plugin/marketplace.json`.

### Reviewer asks

1. Is the tool-agnostic posture right, or should some agents be deprioritised in the install table?
2. Acceptable marketplace name (`inverter-standard` vs. `inverter` vs. `inverter-network`)?
3. Fill in `owner.email` now, or leave omitted?
4. Pin the Superpowers entry to a specific commit/tag now, or accept upstream-`main` tracking and pin later when there's a clear audit cadence?

🤖 Generated with [Claude Code](https://claude.com/claude-code)